### PR TITLE
Add advanced token tracking features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  AstrBot Token管理插件
 
-## 目前支持兼容openai格式的llm
+## 目前支持兼容openai及其他返回usage字段的llm
 ## 📝 功能特性
 
 - 🔄 自动统计每个会话的token使用量
@@ -9,6 +9,11 @@
 - ⚠️ token使用量达到上限时通知管理员
 - 🛠️ 支持管理员手动重置token计数
 - 💾 自动保存并加载token统计数据
+- 📈 Token使用趋势图生成
+- 📤 支持导出Token记录(JSON/CSV)
+- 💰 自定义Token计费
+- 🛡️ 群组及用户级别Token配额管理
+- 🚨 Token异常使用检测
 
 ## 💡 使用方法
 
@@ -18,6 +23,8 @@
 | `/token_check` | 查看当前会话token使用情况 | 所有人 |
 | `/reset_tokens` | 重置所有token计数 | 仅管理员 |
 | `/token_all` | 查看所有会话的token使用情况 | 仅管理员 |
+| `/token_chart` | 生成Token使用趋势图 | 所有人 |
+| `/export_tokens [json/csv]` | 导出Token记录 | 仅管理员 |
 
 ## ⚙️ 配置说明
 
@@ -25,6 +32,9 @@
 - `max_tokens` - token使用上限配置
   - `group` - 群聊消息token使用上限
   - `private` - 私聊消息token使用上限
+- `cost_per_token` - 单个Token费用
+- `user_limits` - 指定用户Token上限
+- `anomaly_threshold` - 单条消息异常阈值
 
 ## 🎯 功能规划
 
@@ -33,6 +43,8 @@
 - [x] 不同会话类型(群聊/私聊)的token限额设置
 - [x] 基础token统计与显示
 - [x] token使用预警通知
+- [x] Token趋势图与记录导出
+- [x] 用户级别限制与异常检测
 
 
 ## 作者

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -19,11 +19,29 @@
                 "default": 100000
             },
             "private": {
-                "description": "私聊Token上限", 
+                "description": "私聊Token上限",
                 "type": "int",
                 "hint": "私聊消息的token使用上限",
                 "default": 50000
             }
         }
+    },
+    "cost_per_token": {
+        "description": "单个Token费用",
+        "type": "float",
+        "hint": "计算消耗费用时每个Token的单价",
+        "default": 0.0
+    },
+    "user_limits": {
+        "description": "用户Token限制",
+        "type": "object",
+        "hint": "指定用户的Token使用上限",
+        "items": {}
+    },
+    "anomaly_threshold": {
+        "description": "单次消息异常阈值",
+        "type": "int",
+        "hint": "单条消息使用Token超过该值时触发警告",
+        "default": 0
     }
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 name: astrbot_plugin_token_auto
-version: v1.2.0
+version: v1.3.0
 author: FengYing
 desc: Token使用监控与管理插件
 repo: https://github.com/FengYing1314/astrbot_plugin_token_auto
@@ -8,6 +8,8 @@ help: |
   普通命令:
   /token - 开启/关闭token显示
   /token_check - 查看当前token使用情况
+  /token_chart - 生成Token趋势图
   管理员命令:
   /reset_tokens - 重置所有token计数
   /token_all - 查看所有会话使用情况
+  /export_tokens [json/csv] - 导出Token记录


### PR DESCRIPTION
## Summary
- support more LLM response formats
- add cost per token and user limits
- save token usage history and export CSV/JSON
- provide usage trend chart command
- document new options and commands

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_683d799f6a488321a1a3c5c2f1cd685d